### PR TITLE
Add Setup Guide Reference to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A modern e-commerce web application built with **React** and **Vite**, styled wi
 
 ## Project Structure
 
-``` 
+```
 .
 └── cvsam-canvie-e-comm/
     ├── README.md                   # Project documentation
@@ -161,8 +161,6 @@ The setup guide includes detailed instructions for:
 - Project structure creation
 - Development server instructions
 - Troubleshooting common issues
-
-This documentation is particularly valuable for those who wish to replicate our development environment or understand the foundational structure of this project. If you encounter any difficulties following these instructions, please consult the troubleshooting section in the setup guide or open an issue in our issue tracker.
 
 ## Creating Issues
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@ A modern e-commerce web application built with **React** and **Vite**, styled wi
 
 1. [Features](#features)
 2. [Project Structure](#project-structure)
-3. [Getting Started](#️getting-started)
-    - [Prerequisites](#prerequisites)
-    - [Installation](#installation)
+3. [Getting Started](#getting-started)
+   - [Prerequisites](#prerequisites)
+   - [Installation](#installation)
 4. [Firebase Configuration](#firebase-configuration)
 5. [Available Scripts](#available-scripts)
-6. [ESLint Configuration](#️eslint-configuration)
+6. [ESLint Configuration](#eslint-configuration)
 7. [Contributing](#contributing)
-8. [Creating Issues](#creating-issues)
-9. [Acknowledgments](#acknowledgments)
+8. [Setup Instructions](#setup-instructions)
+9. [Creating Issues](#creating-issues)
+10. [Acknowledgments](#acknowledgments)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A modern e-commerce web application built with **React** and **Vite**, styled with **Tailwind CSS**, and integrated with **Firebase** for authentication and database management. This project aims to provide a smooth shopping experience, featuring responsive design, user authentication, and product management.
 
-## 📚Table of Contents
+## Table of Contents
 
 1. [Features](#features)
 2. [Project Structure](#project-structure)
@@ -16,15 +16,15 @@ A modern e-commerce web application built with **React** and **Vite**, styled wi
 8. [Creating Issues](#creating-issues)
 9. [Acknowledgments](#acknowledgments)
 
-## 🚀Features
+## Features
 
-- ⚡ **Vite**: Fast build tool with HMR for seamless development.
-- ⚛️ **React 18**: Modern component-based UI library.
-- 🎨 **Tailwind CSS**: Utility-first CSS framework for responsive designs.
-- 🔥 **Firebase**: Integrated authentication and Firestore database.
-- ✅ **ESLint**: Pre-configured for React with best practices and hooks rules.
+- **Vite**: Fast build tool with HMR for seamless development.
+- **React 18**: Modern component-based UI library.
+- **Tailwind CSS**: Utility-first CSS framework for responsive designs.
+- **Firebase**: Integrated authentication and Firestore database.
+- **ESLint**: Pre-configured for React with best practices and hooks rules.
 
-## 📦Project Structure
+## Project Structure
 
 ``` 
 .
@@ -44,7 +44,7 @@ A modern e-commerce web application built with **React** and **Vite**, styled wi
         └── services/               # Firebase configuration and services
 ```
 
-## 🛠️Getting Started
+## Getting Started
 
 ### Prerequisites
 
@@ -54,66 +54,71 @@ A modern e-commerce web application built with **React** and **Vite**, styled wi
 ### Installation
 
 1. Clone the repository:
-    ```bash
-    git clone https://github.com/cvsam/CANVIE-E-COMM.git
-    cd cvsam-canvie-e-comm
-    ```
+
+   ```bash
+   git clone https://github.com/cvsam/CANVIE-E-COMM.git
+   cd cvsam-canvie-e-comm
+   ```
 
 2. Install Yarn globally if you haven't already:
-    ```bash
-    npm install -g yarn
-    ```
+
+   ```bash
+   npm install -g yarn
+   ```
 
 3. Install project dependencies:
-    ```bash
-    yarn install
-    ```
+
+   ```bash
+   yarn install
+   ```
 
 4. Start the development server:
-    ```bash
-    yarn dev
-    ```
+   ```bash
+   yarn dev
+   ```
 
-## 🔥Firebase Configuration
+## Firebase Configuration
 
 1. Create a `.env` file in the root directory:
-    ```env
-    VITE_API_KEY=your_api_key
-    VITE_AUTH_DOMAIN=your_auth_domain
-    VITE_PROJECT_ID=your_project_id
-    VITE_STORAGE_BUCKET=your_storage_bucket
-    VITE_MESSAGING_SENDER_ID=your_messaging_sender_id
-    VITE_APP_ID=your_app_id
-    ```
+
+   ```env
+   VITE_API_KEY=your_api_key
+   VITE_AUTH_DOMAIN=your_auth_domain
+   VITE_PROJECT_ID=your_project_id
+   VITE_STORAGE_BUCKET=your_storage_bucket
+   VITE_MESSAGING_SENDER_ID=your_messaging_sender_id
+   VITE_APP_ID=your_app_id
+   ```
 
 2. Initialize Firebase services in `src/services/firebase.js`:
-    ```javascript
-    import { initializeApp } from "firebase/app";
-    import { getAuth } from "firebase/auth";
-    import { getFirestore } from "firebase/firestore";
 
-    const firebaseConfig = {
-        apiKey: import.meta.env.VITE_API_KEY,
-        authDomain: import.meta.env.VITE_AUTH_DOMAIN,
-        projectId: import.meta.env.VITE_PROJECT_ID,
-        storageBucket: import.meta.env.VITE_STORAGE_BUCKET,
-        messagingSenderId: import.meta.env.VITE_MESSAGING_SENDER_ID,
-        appId: import.meta.env.VITE_APP_ID,
-    };
+   ```javascript
+   import { initializeApp } from "firebase/app";
+   import { getAuth } from "firebase/auth";
+   import { getFirestore } from "firebase/firestore";
 
-    const app = initializeApp(firebaseConfig);
-    export const auth = getAuth(app);
-    export const db = getFirestore(app);
-    ```
+   const firebaseConfig = {
+     apiKey: import.meta.env.VITE_API_KEY,
+     authDomain: import.meta.env.VITE_AUTH_DOMAIN,
+     projectId: import.meta.env.VITE_PROJECT_ID,
+     storageBucket: import.meta.env.VITE_STORAGE_BUCKET,
+     messagingSenderId: import.meta.env.VITE_MESSAGING_SENDER_ID,
+     appId: import.meta.env.VITE_APP_ID,
+   };
 
-## 📋Available Scripts
+   const app = initializeApp(firebaseConfig);
+   export const auth = getAuth(app);
+   export const db = getFirestore(app);
+   ```
+
+## Available Scripts
 
 - `yarn dev` → Runs the app in development mode with HMR.
 - `yarn build` → Builds the app for production.
 - `yarn preview` → Serves the production build locally.
 - `yarn lint` → Runs ESLint for code quality checks.
 
-## ⚙️ESLint Configuration
+## ESLint Configuration
 
 This project uses ESLint for maintaining code quality. The configuration includes the following rules:
 
@@ -122,32 +127,47 @@ This project uses ESLint for maintaining code quality. The configuration include
 - Prettier integration (`eslint-plugin-prettier`)
 
 To run the linter:
+
 ```bash
 yarn lint
 ```
 
-## 🤝Contributing
+## Contributing
 
 1. Fork the repository.
 2. Create your feature branch:
-    ```bash
-    git checkout -b feature/awesome-feature
-    ```
+   ```bash
+   git checkout -b feature/awesome-feature
+   ```
 3. Commit your changes:
-    ```bash
-    git commit -m "Add awesome feature"
-    ```
+   ```bash
+   git commit -m "Add awesome feature"
+   ```
 4. Push to the branch:
-    ```bash
-    git push origin feature/awesome-feature
-    ```
+   ```bash
+   git push origin feature/awesome-feature
+   ```
 5. Open a pull request.
 
-## 🐛Creating Issues
+## Setup Instructions
+
+For developers interested in creating or setting up a similar environment or project from scratch, we provide comprehensive documentation in our [Setup Guide](./SETUP.md).
+The setup guide includes detailed instructions for:
+
+- Project initialization steps
+- Required dependencies installation
+- Configuration file setup
+- Project structure creation
+- Development server instructions
+- Troubleshooting common issues
+
+This documentation is particularly valuable for those who wish to replicate our development environment or understand the foundational structure of this project. If you encounter any difficulties following these instructions, please consult the troubleshooting section in the setup guide or open an issue in our issue tracker.
+
+## Creating Issues
 
 If you encounter any bugs or have feature requests, please create an issue on the [GitHub Issues](https://github.com/cvsam/CANVIE-E-COMM.git/issues) page.
 
-## 🌟Acknowledgments
+## Acknowledgments
 
 - [Vite](https://vitejs.dev/)
 - [React](https://reactjs.org/)


### PR DESCRIPTION
## Overview

This PR addresses issue #6 by adding a new section to the `README.md` that references the `SETUP.md` file. The section specifically targets developers who want to create or set up a similar environment or project from scratch.

## Changes

- [x]  Add a new section titled "Setup" or "Installation" to `README.md`
- [x]  Include a brief description explaining what `SETUP.md` contains
- [x]  Add a properly formatted markdown link to `SETUP.md`
- [x]  Ensure the link works correctly when navigating the repository
- [x]  Position the new section in a logical place within `README.md`

## Implementation Details

The new section has been positioned logically within the `README.md` file and provides enough context for users to understand when they might need to reference the `SETUP.md` document. The wording specifically indicates that the setup guide is for developers interested in creating similar environments or understanding the project structure from scratch.

## Related Issues
Closes #6 